### PR TITLE
Поменял x на html-крест в файлах

### DIFF
--- a/install/admin/sprint.editor/assets/complex_builder.js
+++ b/install/admin/sprint.editor/assets/complex_builder.js
@@ -122,7 +122,7 @@ function complex_builder($, currentEditorParams, currentEditorValue) {
         let html = '';
         html += '<div class="sp-x-lt">';
         html += '<div class="sp-x-lt-header">';
-        html += '<span class="sp-x-del">x</span>';
+        html += '<span class="sp-x-del">&times;</span>';
         html += '<span class="sp-x-caption" contenteditable="true">' + title + '</span>';
         html += '</div>';
         html += '<div class="sp-table">';

--- a/install/admin/sprint.editor/blocks/box/template.html
+++ b/install/admin/sprint.editor/blocks/box/template.html
@@ -24,7 +24,7 @@
                     <span class="sp-x-btn sp-x-box-collapse">Свернуть</span>
                 </div>
                 <div class="sp-x-pp-group">
-                    <span title="Удалить блок" class="sp-x-btn sp-x-box-del">x Удалить</span>
+                    <span title="Удалить блок" class="sp-x-btn sp-x-box-del">&times; Удалить</span>
                 </div>
                 <div class="sp-x-pp-group">
                     <div class="sp-x-note">Название блока: {{=it.blockName}}</div>


### PR DESCRIPTION
X выглядит странновато, как-то недоделано, поменял на `&times;`.
Нашел в 2 местах, если есть еще файлы - напиши, поправлю и там.

Было:
![before](https://github.com/Ruslan-Aleev/sprint.editor/assets/12523676/90202fd0-3b75-4fdd-97f1-f4bf4eb1762f)

Стало:
![after](https://github.com/Ruslan-Aleev/sprint.editor/assets/12523676/118ff9f5-7b25-434c-91ec-53d63c49df6f)
